### PR TITLE
Add Dependabot configuration

### DIFF
--- a/Buddy_Crocker/.github/dependabot.yml
+++ b/Buddy_Crocker/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # 1) Keep Python dependencies (requirements.txt) up to date
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # 2) Keep GitHub Actions (your CI workflows) up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add Dependabot for Dependency Security & GitHub Actions Updates

This PR introduces Dependabot configuration to automate checking for outdated or vulnerable dependencies in our Django project.